### PR TITLE
Changed template to prevent unwanted issue linking

### DIFF
--- a/.github/ISSUE_TEMPLATE/what-if-noise-report.md
+++ b/.github/ISSUE_TEMPLATE/what-if-noise-report.md
@@ -15,7 +15,7 @@ assignees: ''
 
 **Client (PowerShell, Azure CLI, or API)**
 
-**Relevant ARM Template code (we only need the resource object specified in #1 and #2, but if it's easier you can include the entire template**
+**Relevant ARM Template code (we only need the resource object specified in nr 1 and  nr 2, but if it's easier you can include the entire template**
 
 **Expected response (i.e. "I expected no noise since the template has not been modified since the resources were deployed)**
 


### PR DESCRIPTION
I noticed with the template that using a hashtag with numbers is not a good idea.
Currently, it would link all new issues to 

https://github.com/Azure/arm-template-whatif/issues/1

and

https://github.com/Azure/arm-template-whatif/issues/2